### PR TITLE
Make Bill__c.Account__c not required - part 2

### DIFF
--- a/force-app/main/default/layouts/Bill__c-Bill Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Bill__c-Bill Layout.layout-meta.xml
@@ -15,7 +15,7 @@
                 <field>Invoice_Number__c</field>
             </layoutItems>
             <layoutItems>
-                <behavior>Required</behavior>
+                <behavior>Edit</behavior>
                 <field>Account__c</field>
             </layoutItems>
             <layoutItems>


### PR DESCRIPTION
Removing the required flag from the page layout as well to match the field having the required flag removed.